### PR TITLE
针对“1.3 配置 3节点的集群，同时满足以下要求“中条件三“保证集群‘green’状态”问题修复

### DIFF
--- a/review-practice/0012_zhenti.md
+++ b/review-practice/0012_zhenti.md
@@ -118,6 +118,7 @@ PUT a_index
 {
   "settings": {
     "index.routing.allocation.include.size": "big"
+    "index.number_of_replicas":0
   }
 }
 


### PR DESCRIPTION
由于索引A分片全部落在节点1上，而默认情况下index.numer_of_replicas是1，那么将会出现replica shard unsigned状态，则导致集群健康态是‘yellow’。因此，在设置A索引setting时，需要把index.numer_of_replicas置为0。那么就可满足条件3，‘不允许删除数据的情况下，保证集群状态为 Green’。